### PR TITLE
Fix for #37

### DIFF
--- a/src/BeenPwnedApp/Core/BeenPwned.App.Core.csproj
+++ b/src/BeenPwnedApp/Core/BeenPwned.App.Core.csproj
@@ -72,6 +72,7 @@
     </Compile>
     <Compile Include="Controls\BorderlessEntry.cs" />
     <Compile Include="Converters\InverseBoolConverter.cs" />
+    <Compile Include="ViewCells\UnselectableCell.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/BeenPwnedApp/Core/Pages/BreachPage.xaml
+++ b/src/BeenPwnedApp/Core/Pages/BreachPage.xaml
@@ -9,13 +9,13 @@
 	<ContentPage.Content>
         <TableView Intent="Form" HasUnevenRows="true" Margin="0,-45,0,0">
             <TableSection>
-                <ViewCell>
+                <cells:UnselectableCell>
                     <StackLayout BackgroundColor="#191919" HeightRequest="90">
                         <ffimageloadingsvg:SvgCachedImage Margin="0,30,0,0" HeightRequest="40" WidthRequest="80" HorizontalOptions="Center" VerticalOptions="Center"
                             DownsampleToViewSize="true" Source="{Binding Breach, Converter={StaticResource BreachToImageUrlConverter}}">
                         </ffimageloadingsvg:SvgCachedImage>
                     </StackLayout>
-                </ViewCell>
+                </cells:UnselectableCell>
             </TableSection>
             <TableSection Title="Breach details">
                 <cells:BasicDataCell Label="Domain" Text="{Binding Breach.Domain}" />

--- a/src/BeenPwnedApp/Core/ViewCells/UnselectableCell.cs
+++ b/src/BeenPwnedApp/Core/ViewCells/UnselectableCell.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace BeenPwned.App.Core.ViewCells
+{
+    public class UnselectableCell : ViewCell
+    {
+    }
+}

--- a/src/BeenPwnedApp/iOS/BeenPwned.App.iOS.csproj
+++ b/src/BeenPwnedApp/iOS/BeenPwned.App.iOS.csproj
@@ -230,6 +230,7 @@
     <Compile Include="AkavacheSqliteLinkerOverride.cs" />
     <Compile Include="Renderers\ExtendedWebViewRenderer.cs" />
     <Compile Include="Renderers\BorderlessEntryRenderer.cs" />
+    <Compile Include="Renderers\UnselectableCellRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\BeenPwned.App.Core.csproj">

--- a/src/BeenPwnedApp/iOS/Renderers/UnselectableCellRenderer.cs
+++ b/src/BeenPwnedApp/iOS/Renderers/UnselectableCellRenderer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using BeenPwned.App.Core.ViewCells;
+using BeenPwned.App.iOS.Renderers;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(UnselectableCell), typeof(UnselectableCellRenderer))]
+namespace BeenPwned.App.iOS.Renderers
+{
+    public class UnselectableCellRenderer : ViewCellRenderer
+    {
+        public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+        {
+            var cell = base.GetCell(item, reusableCell, tv);
+
+            cell.SelectedBackgroundView = new UIView() { BackgroundColor = UIColor.Clear };
+            cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+
+            return cell;
+        }
+    }
+}


### PR DESCRIPTION
Fixed this by creating a custom cell that has a renderer on iOS setting its `SelectionType` to `None`. No more selection colors happening.